### PR TITLE
Fix manifest documentation URL

### DIFF
--- a/custom_components/krisinformation/manifest.json
+++ b/custom_components/krisinformation/manifest.json
@@ -3,7 +3,7 @@
   "name": "Krisinformation",
   "codeowners": ["@Nicxe"],
   "config_flow": true,
-  "documentation": "https://github.com/Nicxe//krisinformation",
+  "documentation": "https://github.com/Nicxe/krisinformation",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/Nicxe/krisinformation/issues",
   "version": "0.1.1"


### PR DESCRIPTION
## Summary
- fix documentation URL in `manifest.json`
- end file with newline

## Testing
- `python -m py_compile custom_components/krisinformation/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6845687e8c748322948104994b0dde26