### PR TITLE
chore: Fix cross-spawn and brace-expansion security vulnerabilities

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,18 @@
 version: 2
+
+registries:
+  github-packages:
+    type: npm-registry
+    url: https://npm.pkg.github.com
+    token: ${{ secrets.DEPENDABOT_GH_PACKAGES_TOKEN }}
+
 updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "daily"
+    registries:
+      - github-packages
     open-pull-requests-limit: 10
     labels:
       - "dependencies"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -3,6 +3,7 @@ name: Validate
 on:
   push:
     branches: [dev, beta, main]
+  pull_request:
   workflow_dispatch:
 
 permissions:

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@nicxe:registry=https://npm.pkg.github.com

--- a/package-lock.json
+++ b/package-lock.json
@@ -113,9 +113,9 @@
       }
     },
     "node_modules/@nicxe/semantic-release-config": {
-      "version": "1.0.5",
-      "resolved": "https://npm.pkg.github.com/download/@nicxe/semantic-release-config/1.0.5/92aa18080e34a341fcc43ed825f16dba6ded96b2",
-      "integrity": "sha512-t4NLKDh3ZZ99tUWu0crQIiO+Hodq2xMsgbX3n1PaCJ8ZoSi/Gv1SHtpcN6vD6/83wCrVCCetgZf2jLcWjL20dg==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@nicxe/semantic-release-config/1.0.7/18e931f0f1384759818cda5383c400fce0afb17b",
+      "integrity": "sha512-C70Sjju+dJGHMWIQWuFdwbPwL5Hc+NwdtGJ+1+NSyx7kwNjcbW2rM/DqPOvwHSf1VlMHKtyH6rqpNPNzcLj5KA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -5655,9 +5655,9 @@
       }
     },
     "node_modules/tempy": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tempy/-/tempy-3.1.0.tgz",
-      "integrity": "sha512-7jDLIdD2Zp0bDe5r3D2qtkd1QOCacylBuL7oa4udvN6v2pqr4+LcCr67C8DR1zkpaZ8XosF5m1yQSabKAW6f2g==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tempy/-/tempy-3.1.1.tgz",
+      "integrity": "sha512-ozXJ+Z2YduKpJuuM07LNcIxpX+r8W4J84HrgqB/ay4skWfa5MhjsVn6e2fw+bRDa8cYO5jRJWnEMWL1HqCc2sQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5862,9 +5862,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.18.2.tgz",
-      "integrity": "sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.19.0.tgz",
+      "integrity": "sha512-Heho1hJD81YChi+uS2RkSjcVO+EQLmLSyUlHyp7Y/wFbxQaGb4WXVKD073JytrjXJVkSZVzoE2MCSOKugFGtOQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "semantic-release": "^25.0.2"
   },
   "overrides": {
-    "tar": "^7.5.3"
+    "tar": "^7.5.3",
+    "cross-spawn": "^7.0.6",
+    "brace-expansion": "^2.0.2"
   }
 }


### PR DESCRIPTION
## Summary
- Add npm overrides to resolve CVE-2024-21538 (cross-spawn ReDoS vulnerability)
- Add npm override for brace-expansion vulnerability

These are transitive dependencies from semantic-release that Dependabot flagged as security issues.

## Test plan
- Verify Dependabot alerts are resolved after merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)