### PR TITLE
fix: Remove replaces-base from Dependabot registry config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,6 @@ registries:
     type: npm-registry
     url: https://npm.pkg.github.com
     token: ${{ secrets.DEPENDABOT_GH_PACKAGES_TOKEN }}
-    replaces-base: true
 
 updates:
   - package-ecosystem: "npm"


### PR DESCRIPTION
## Summary
- Removes `replaces-base: true` from the GitHub Packages registry configuration
- This was causing Dependabot to fetch ALL packages from GitHub Packages instead of just @nicxe scoped packages
- Without this option, Dependabot uses GitHub Packages as an additional registry alongside npmjs.com

## Root cause
The `replaces-base: true` option tells Dependabot to use GitHub Packages as the **only** registry, replacing npmjs.com entirely. This caused 404 errors for packages like `@semantic-release/*` that only exist on npmjs.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)