### PR TITLE
chore: Remove GitHub Packages registry configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,10 @@
 version: 2
 
-registries:
-  github-packages:
-    type: npm-registry
-    url: https://npm.pkg.github.com
-    token: ${{ secrets.DEPENDABOT_GH_PACKAGES_TOKEN }}
-    replaces-base: true
-
 updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "daily"
-    registries:
-      - github-packages
     open-pull-requests-limit: 10
     labels:
       - "dependencies"

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-@nicxe:registry=https://npm.pkg.github.com


### PR DESCRIPTION
## Summary
- Remove Dependabot registry configuration for GitHub Packages
- Delete `.npmrc` file

Since `@nicxe/semantic-release-config` is now published to npmjs.com, the custom registry configuration is no longer needed. This simplifies the setup and eliminates the need for the `DEPENDABOT_GH_PACKAGES_TOKEN` secret.

After merging, you can delete the `DEPENDABOT_GH_PACKAGES_TOKEN` secret from Settings > Secrets and variables > Dependabot.