### PR TITLE
chore: add issue templates for integration and card

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,68 @@
+name: 🐞 Bug Report
+description: Report a problem with Krisinformation
+title: "[Bug]: "
+labels: ["bug"]
+assignees: ["Nicxe"]
+body:
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part is affected?
+      options:
+        - Integration
+        - Card
+        - Both
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: prerequisites
+    attributes:
+      label: Prerequisites
+      options:
+        - label: I am running the latest release
+          required: true
+        - label: I have searched existing issues
+          required: true
+        - label: I have restarted Home Assistant
+          required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Release Version
+      placeholder: e.g. 1.2.3
+    validations:
+      required: true
+
+  - type: textarea
+    id: current_behavior
+    attributes:
+      label: Current Behavior
+      description: What is happening?
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected Behavior
+      description: What should happen?
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        ### Logs and diagnostics
+
+        For integration issues, enable debug logging before sharing logs.
+        For card issues, include your card configuration and browser console errors.
+
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Logs / Browser Console / Card Config
+      description: Paste relevant diagnostics here.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,39 @@
+name: 🚀 Feature Request
+description: Suggest an improvement or new feature
+title: "[Feature]: "
+labels: ["enhancement"]
+assignees: ["Nicxe"]
+body:
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part should be improved?
+      options:
+        - Integration
+        - Card
+        - Both
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem to Solve
+      description: What problem does this feature address?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: How should it work?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives
+      description: Any alternative approaches?

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,29 @@
+name: ❓ Question
+description: Ask a question about Krisinformation (integration or card)
+labels: ["question"]
+body:
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: What is your question about?
+      options:
+        - Integration
+        - Card
+        - Both
+    validations:
+      required: true
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Your Question
+      description: Describe what you need help with.
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Share relevant details, configuration, and what you already tried.

--- a/.github/workflows/label-component.yml
+++ b/.github/workflows/label-component.yml
@@ -1,0 +1,65 @@
+name: Label Issue Component
+
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  issues: write
+
+jobs:
+  label-component:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply component label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.payload.issue.number;
+            const body = context.payload.issue.body || '';
+
+            const match = body.match(/### Component\s*\n+([^\n]+)/i);
+            if (!match) {
+              core.info('No component section found in issue body.');
+              return;
+            }
+
+            const selected = match[1].trim().toLowerCase();
+            const integrationLabel = 'Integration';
+            const cardLabel = 'Card';
+
+            let desired = [];
+            if (selected === 'integration') desired = [integrationLabel];
+            if (selected === 'card') desired = [cardLabel];
+            if (selected === 'both') desired = [integrationLabel, cardLabel];
+
+            if (desired.length === 0) {
+              core.info(`Unknown component value: ${selected}`);
+              return;
+            }
+
+            for (const label of [integrationLabel, cardLabel]) {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name: label });
+              } catch (error) {
+                if (error.status === 404) {
+                  await github.rest.issues.createLabel({ owner, repo, name: label, color: '0e8a16' });
+                } else {
+                  throw error;
+                }
+              }
+            }
+
+            const currentLabels = context.payload.issue.labels.map((l) => l.name);
+            const toAdd = desired.filter((l) => !currentLabels.includes(l));
+            const toRemove = [integrationLabel, cardLabel].filter((l) => !desired.includes(l) && currentLabels.includes(l));
+
+            if (toAdd.length) {
+              await github.rest.issues.addLabels({ owner, repo, issue_number, labels: toAdd });
+            }
+
+            for (const label of toRemove) {
+              await github.rest.issues.removeLabel({ owner, repo, issue_number, name: label });
+            }


### PR DESCRIPTION
Adds issue templates for bug reports, feature requests, and questions with a component choice for integration/card/both.\n\nAlso adds automatic component labeling with `Integration` and `Card` based on the selected template value.