### PR TITLE
chore: update overrides to fix undici and tar security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,19 +46,6 @@
         "undici": "^5.28.5"
       }
     },
-    "node_modules/@actions/http-client/node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.0"
-      }
-    },
     "node_modules/@actions/io": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@actions/io/-/io-2.0.0.tgz",
@@ -100,16 +87,6 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
-      }
-    },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@nicxe/semantic-release-config": {
@@ -2408,9 +2385,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "11.11.1",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-11.11.1.tgz",
-      "integrity": "sha512-asazCodkFdz1ReQzukyzS/DD77uGCIqUFeRG3gtaT8b9UR0ne1m9QOBuMgT72ij1rt7TRrOox4A1WzntMWIuEg==",
+      "version": "11.10.1",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.10.1.tgz",
+      "integrity": "sha512-woavuY2OgDFQ1K/tB9QHsUuW989nKfvsKTN/h5qGyS+3+BhvXN/DA2TNzx569JaFfTqrET5bEQNHwVhFk+U1gg==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -2489,7 +2466,7 @@
       ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^9.4.1",
+        "@npmcli/arborist": "^9.3.1",
         "@npmcli/config": "^10.7.1",
         "@npmcli/fs": "^5.0.0",
         "@npmcli/map-workspaces": "^5.0.3",
@@ -2497,7 +2474,7 @@
         "@npmcli/package-json": "^7.0.5",
         "@npmcli/promise-spawn": "^9.0.1",
         "@npmcli/redact": "^4.0.0",
-        "@npmcli/run-script": "^10.0.4",
+        "@npmcli/run-script": "^10.0.3",
         "@sigstore/tuf": "^4.0.1",
         "abbrev": "^4.0.0",
         "archy": "~1.0.0",
@@ -2514,17 +2491,17 @@
         "is-cidr": "^6.0.3",
         "json-parse-even-better-errors": "^5.0.0",
         "libnpmaccess": "^10.0.3",
-        "libnpmdiff": "^8.1.4",
-        "libnpmexec": "^10.2.4",
-        "libnpmfund": "^7.0.18",
+        "libnpmdiff": "^8.1.2",
+        "libnpmexec": "^10.2.2",
+        "libnpmfund": "^7.0.16",
         "libnpmorg": "^8.0.1",
-        "libnpmpack": "^9.1.4",
+        "libnpmpack": "^9.1.2",
         "libnpmpublish": "^11.1.3",
         "libnpmsearch": "^9.0.1",
         "libnpmteam": "^8.0.2",
         "libnpmversion": "^8.0.3",
-        "make-fetch-happen": "^15.0.4",
-        "minimatch": "^10.2.4",
+        "make-fetch-happen": "^15.0.3",
+        "minimatch": "^10.2.2",
         "minipass": "^7.1.3",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
@@ -2538,7 +2515,7 @@
         "npm-registry-fetch": "^19.1.1",
         "npm-user-validate": "^4.0.0",
         "p-map": "^7.0.4",
-        "pacote": "^21.5.0",
+        "pacote": "^21.3.1",
         "parse-conflict-json": "^5.0.1",
         "proc-log": "^6.1.0",
         "qrcode-terminal": "^0.12.0",
@@ -2547,7 +2524,7 @@
         "spdx-expression-parse": "^4.0.0",
         "ssri": "^13.0.1",
         "supports-color": "^10.2.2",
-        "tar": "^7.5.11",
+        "tar": "^7.5.9",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^2.0.2",
         "treeverse": "^3.0.0",
@@ -2592,27 +2569,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/npm/node_modules/@gar/promise-retry": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "retry": "^0.13.1"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/@gar/promise-retry/node_modules/retry": {
-      "version": "0.13.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/npm/node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
       "dev": true,
@@ -2648,12 +2604,11 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "9.4.1",
+      "version": "9.3.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@gar/promise-retry": "^1.0.0",
         "@isaacs/string-locale-compare": "^1.1.0",
         "@npmcli/fs": "^5.0.0",
         "@npmcli/installed-package-contents": "^4.0.0",
@@ -2727,17 +2682,17 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/git": {
-      "version": "7.0.2",
+      "version": "7.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@gar/promise-retry": "^1.0.0",
         "@npmcli/promise-spawn": "^9.0.0",
         "ini": "^6.0.0",
         "lru-cache": "^11.2.1",
         "npm-pick-manifest": "^11.0.1",
         "proc-log": "^6.0.0",
+        "promise-retry": "^2.0.1",
         "semver": "^7.3.5",
         "which": "^6.0.0"
       },
@@ -2862,7 +2817,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/run-script": {
-      "version": "10.0.4",
+      "version": "10.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -2871,7 +2826,8 @@
         "@npmcli/package-json": "^7.0.0",
         "@npmcli/promise-spawn": "^9.0.0",
         "node-gyp": "^12.1.0",
-        "proc-log": "^6.0.0"
+        "proc-log": "^6.0.0",
+        "which": "^6.0.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -3004,12 +2960,12 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/balanced-match": {
-      "version": "4.0.4",
+      "version": "4.0.3",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/npm/node_modules/bin-links": {
@@ -3041,7 +2997,7 @@
       }
     },
     "node_modules/npm/node_modules/brace-expansion": {
-      "version": "5.0.4",
+      "version": "5.0.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3049,7 +3005,7 @@
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/npm/node_modules/cacache": {
@@ -3175,6 +3131,16 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/npm/node_modules/encoding": {
+      "version": "0.1.13",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
     "node_modules/npm/node_modules/env-paths": {
       "version": "2.2.1",
       "dev": true,
@@ -3285,7 +3251,7 @@
       }
     },
     "node_modules/npm/node_modules/iconv-lite": {
-      "version": "0.7.2",
+      "version": "0.6.3",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3295,10 +3261,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/npm/node_modules/ignore-walk": {
@@ -3431,12 +3393,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "8.1.4",
+      "version": "8.1.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.1",
+        "@npmcli/arborist": "^9.3.1",
         "@npmcli/installed-package-contents": "^4.0.0",
         "binary-extensions": "^3.0.0",
         "diff": "^8.0.2",
@@ -3450,19 +3412,19 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "10.2.4",
+      "version": "10.2.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@gar/promise-retry": "^1.0.0",
-        "@npmcli/arborist": "^9.4.1",
+        "@npmcli/arborist": "^9.3.1",
         "@npmcli/package-json": "^7.0.0",
         "@npmcli/run-script": "^10.0.0",
         "ci-info": "^4.0.0",
         "npm-package-arg": "^13.0.0",
         "pacote": "^21.0.2",
         "proc-log": "^6.0.0",
+        "promise-retry": "^2.0.1",
         "read": "^5.0.1",
         "semver": "^7.3.7",
         "signal-exit": "^4.1.0",
@@ -3473,12 +3435,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "7.0.18",
+      "version": "7.0.16",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.1"
+        "@npmcli/arborist": "^9.3.1"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -3498,12 +3460,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "9.1.4",
+      "version": "9.1.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.1",
+        "@npmcli/arborist": "^9.3.1",
         "@npmcli/run-script": "^10.0.0",
         "npm-package-arg": "^13.0.0",
         "pacote": "^21.0.2"
@@ -3582,12 +3544,11 @@
       }
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
-      "version": "15.0.4",
+      "version": "15.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@gar/promise-retry": "^1.0.0",
         "@npmcli/agent": "^4.0.0",
         "cacache": "^20.0.1",
         "http-cache-semantics": "^4.1.1",
@@ -3597,6 +3558,7 @@
         "minipass-pipeline": "^1.2.4",
         "negotiator": "^1.0.0",
         "proc-log": "^6.0.0",
+        "promise-retry": "^2.0.1",
         "ssri": "^13.0.0"
       },
       "engines": {
@@ -3604,7 +3566,7 @@
       }
     },
     "node_modules/npm/node_modules/minimatch": {
-      "version": "10.2.4",
+      "version": "10.2.2",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -3640,7 +3602,7 @@
       }
     },
     "node_modules/npm/node_modules/minipass-fetch": {
-      "version": "5.0.2",
+      "version": "5.0.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3653,7 +3615,7 @@
         "node": "^20.17.0 || >=22.9.0"
       },
       "optionalDependencies": {
-        "iconv-lite": "^0.7.2"
+        "encoding": "^0.1.13"
       }
     },
     "node_modules/npm/node_modules/minipass-flush": {
@@ -3861,7 +3823,7 @@
       }
     },
     "node_modules/npm/node_modules/npm-packlist": {
-      "version": "10.0.4",
+      "version": "10.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -3942,12 +3904,11 @@
       }
     },
     "node_modules/npm/node_modules/pacote": {
-      "version": "21.5.0",
+      "version": "21.3.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@gar/promise-retry": "^1.0.0",
         "@npmcli/git": "^7.0.0",
         "@npmcli/installed-package-contents": "^4.0.0",
         "@npmcli/package-json": "^7.0.0",
@@ -3961,6 +3922,7 @@
         "npm-pick-manifest": "^11.0.1",
         "npm-registry-fetch": "^19.0.0",
         "proc-log": "^6.0.0",
+        "promise-retry": "^2.0.1",
         "sigstore": "^4.0.0",
         "ssri": "^13.0.0",
         "tar": "^7.4.3"
@@ -4217,7 +4179,7 @@
       }
     },
     "node_modules/npm/node_modules/spdx-license-ids": {
-      "version": "3.0.23",
+      "version": "3.0.22",
       "dev": true,
       "inBundle": true,
       "license": "CC0-1.0"
@@ -4247,7 +4209,7 @@
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "7.5.11",
+      "version": "7.5.9",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -4406,11 +4368,12 @@
       }
     },
     "node_modules/npm/node_modules/write-file-atomic": {
-      "version": "7.0.1",
+      "version": "7.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
+        "imurmurhash": "^0.1.4",
         "signal-exit": "^4.0.1"
       },
       "engines": {
@@ -5685,9 +5648,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.19.1.tgz",
-      "integrity": "sha512-Gpq0iNm5M6cQWlyHQv9MV+uOj1jWk7LpkoE5vSp/7zjb4zMdAcUD+VL5y0nH4p9EbUklq00eVIIX/XcDHzu5xg==",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
+      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -10,9 +10,10 @@
     "semantic-release": "^25.0.3"
   },
   "overrides": {
-    "tar": ">=7.5.8",
+    "tar": "^7.5.11",
     "npm": ">=11.10.1",
     "cross-spawn": "^7.0.6",
-    "brace-expansion": "^2.0.2"
+    "brace-expansion": "^2.0.2",
+    "undici": ">=7.24.0"
   }
 }


### PR DESCRIPTION
## Summary

- Updates the `tar` override from `>=7.5.8` to `^7.5.11` to address a security vulnerability in the tar package.
- Adds a new `undici` override pinned to `>=7.24.0` to address a security vulnerability in the undici package.

## Test plan

- [ ] Verify `npm install` completes without errors
- [ ] Verify `npm audit` shows the relevant vulnerabilities resolved