### PR TITLE
chore: Ignore major GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,10 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
## Summary

Prevent Dependabot from opening routine major-version GitHub Actions update PRs.

## Changes

- Keep grouped GitHub Actions updates enabled for patch and minor releases.
- Ignore semver-major GitHub Actions version updates so breaking workflow changes are handled manually when needed.

## Validation

- Parsed all updated Dependabot YAML files successfully.
