### PR TITLE
fix: **Remove the Krisinformation device lookup deprecation warning**

### DIFF
--- a/custom_components/krisinformation/__init__.py
+++ b/custom_components/krisinformation/__init__.py
@@ -182,7 +182,21 @@ async def _async_migrate_registry_identifiers(
 
     device_registry = dr.async_get(hass)
     legacy_identifier = (DOMAIN, f"{legacy_slug}_{entry.entry_id}")
-    if device := device_registry.async_get_device(identifiers={legacy_identifier}):
+    if get_device := getattr(device_registry, "async_get_device_by_identifier", None):
+        device = get_device(legacy_identifier, entry.entry_id)
+    else:
+        # Home Assistant versions before 2026.8 lack the scoped lookup API.
+        device = next(
+            (
+                candidate
+                for candidate in dr.async_entries_for_config_entry(
+                    device_registry, entry.entry_id
+                )
+                if legacy_identifier in candidate.identifiers
+            ),
+            None,
+        )
+    if device is not None:
         device_registry.async_update_device(
             device.id,
             new_identifiers=(device.identifiers - {legacy_identifier})

--- a/custom_components/krisinformation/tests/test_content_sensor.py
+++ b/custom_components/krisinformation/tests/test_content_sensor.py
@@ -127,10 +127,12 @@ async def test_content_sensors_expose_bounded_normalized_items(
     assert "<" not in news_state.attributes["latest"]["body_text"]
 
     device_registry = dr.async_get(hass)
-    content_device = device_registry.async_get_device(
-        identifiers={content_device_identifier(entry.entry_id)}
-    )
+    news_entity = entity_registry.async_get(news_entity_id)
+    assert news_entity is not None
+    assert news_entity.device_id is not None
+    content_device = device_registry.async_get(news_entity.device_id)
     assert content_device is not None
+    assert content_device.identifiers == {content_device_identifier(entry.entry_id)}
     assert content_device.manufacturer == "Myndigheten för civilt försvar"
     assert KrisinformationNewsSensor._unrecorded_attributes == frozenset(
         {"items", "latest"}

--- a/custom_components/krisinformation/tests/test_init.py
+++ b/custom_components/krisinformation/tests/test_init.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 from datetime import timedelta
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 import re
 
 import pytest
 from aiohttp import ClientError
 from aioresponses import aioresponses
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -21,6 +22,84 @@ from custom_components.krisinformation.const import (
     INTEGRATION_VERSION,
     USER_AGENT_PRODUCT,
 )
+
+
+@pytest.mark.parametrize("device_exists", [True, False])
+async def test_device_migration_uses_config_entry_scoped_lookup(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    device_exists: bool,
+) -> None:
+    """Use the scoped API without calling the deprecated global lookup."""
+    from custom_components.krisinformation import _async_migrate_registry_identifiers
+
+    mock_config_entry.add_to_hass(hass)
+    registry = dr.async_get(hass)
+    identifier = (DOMAIN, f"stockholm_{mock_config_entry.entry_id}")
+    extra_identifier = (DOMAIN, "additional_identifier")
+    device = registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        identifiers={identifier, extra_identifier},
+    )
+
+    with (
+        patch.object(
+            registry,
+            "async_get_device_by_identifier",
+            return_value=device if device_exists else None,
+            create=True,
+        ) as scoped_lookup,
+        patch.object(
+            registry,
+            "async_get_device",
+            side_effect=AssertionError("Deprecated device lookup must not be used"),
+            create=True,
+        ),
+    ):
+        await _async_migrate_registry_identifiers(hass, mock_config_entry)
+
+    scoped_lookup.assert_called_once_with(identifier, mock_config_entry.entry_id)
+    updated = registry.async_get(device.id)
+    assert updated is not None
+    assert updated.identifiers == {
+        (DOMAIN, f"{mock_config_entry.entry_id}_vma") if device_exists else identifier,
+        extra_identifier,
+    }
+
+
+@pytest.mark.parametrize("device_owned_by_entry", [True, False])
+async def test_device_migration_compatibility_is_scoped_to_config_entry(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    device_owned_by_entry: bool,
+) -> None:
+    """The compatibility lookup must only migrate devices owned by this entry."""
+    from custom_components.krisinformation import _async_migrate_registry_identifiers
+
+    mock_config_entry.add_to_hass(hass)
+    other_entry = MockConfigEntry(domain=DOMAIN, entry_id="other_entry")
+    other_entry.add_to_hass(hass)
+    registry = dr.async_get(hass)
+    identifier = (DOMAIN, f"stockholm_{mock_config_entry.entry_id}")
+    other_device = registry.async_get_or_create(
+        config_entry_id=(
+            mock_config_entry.entry_id
+            if device_owned_by_entry
+            else other_entry.entry_id
+        ),
+        identifiers={identifier},
+    )
+
+    with patch.object(registry, "async_get_device_by_identifier", None, create=True):
+        await _async_migrate_registry_identifiers(hass, mock_config_entry)
+
+    updated = registry.async_get(other_device.id)
+    assert updated is not None
+    assert updated.identifiers == {
+        (DOMAIN, f"{mock_config_entry.entry_id}_vma")
+        if device_owned_by_entry
+        else identifier
+    }
 
 
 class TestCoordinatorSetup:


### PR DESCRIPTION
Update the Krisinformation integration to use Home Assistant’s supported device lookup, preventing the warning and maintaining compatibility when the deprecated method is removed. Existing devices and entity IDs are preserved, and older Home Assistant versions remain supported. No configuration changes are required.